### PR TITLE
Convert any timeout specified in the URL to an integer

### DIFF
--- a/lib/tilejson.js
+++ b/lib/tilejson.js
@@ -57,7 +57,7 @@ function TileJSON(uri, callback) {
         if (err) return callback(err);
         tilejson.data = data;
         tilejson.data.id = tilejson.data.id || path.basename(uri.pathname, path.extname(uri.pathname));
-        tilejson.timeout = 'timeout' in uri.query ? uri.query.timeout : 5000;
+        tilejson.timeout = 'timeout' in uri.query ? parseInt(uri.query.timeout, 10) : 5000;
         tilejson.open = true;
         return callback(null, tilejson);
     });


### PR DESCRIPTION
At least with node 0.10 the timeout seems to be ignored by `get` if it is a string.
