### PR TITLE
Register (and handle) tilejson+(https?|file): protocols

### DIFF
--- a/lib/tilejson.js
+++ b/lib/tilejson.js
@@ -65,6 +65,7 @@ function TileJSON(uri, callback) {
 
     // Remote.
     if (/https?:/.test(uri.protocol)) return lock(function(callback) {
+        uri.protocol = uri.protocol.replace(/.*(https?:)/, '$1');
         tilejson.get(url.format(uri), function(err, buffer) {
             if (err && (err.status == 403 || err.status == 404))
                 return callback(new Error('Tileset does not exist'));
@@ -102,6 +103,9 @@ TileJSON.prototype.close = function(callback) {
 
 TileJSON.registerProtocols = function(tilelive) {
     tilelive.protocols['tilejson:'] = TileJSON;
+    tilelive.protocols["tilejson+file:"] = TileJSON;
+    tilelive.protocols["tilejson+http:"] = TileJSON;
+    tilelive.protocols["tilejson+https:"] = TileJSON;
 };
 
 TileJSON.list = function(filepath, callback) {

--- a/test/tilejson.test.js
+++ b/test/tilejson.test.js
@@ -45,6 +45,14 @@ describe('load file', function() {
         });
     });
 
+    it('should load a tilejson file with tilejson+file:', function(done) {
+        new TileJSON('tilejson+file://' + __dirname + '/fixtures/world-bright.tilejson', function(err, source) {
+            assert.ifError(err);
+            assert.ok(source.data);
+            done();
+        });
+    });
+
     it('should return ENOENT for missing file', function(done) {
          new TileJSON('tilejson://' + __dirname + '/fixtures/enoent.tilejson', function(err, source) {
             assert.ok(err);
@@ -81,6 +89,14 @@ describe('load http', function() {
                 assert.equal('943ca1495e3b6e8d84dab88227904190', md5(data));
                 done();
             });
+        });
+    });
+
+    it('loads a tilejson file with tilejson+http:', function(done) {
+        new TileJSON('tilejson+http://a.tiles.mapbox.com/v3/mapbox.world-bright.json', function(err, source) {
+            assert.ifError(err);
+            assert.ok(source.data);
+            done();
         });
     });
 


### PR DESCRIPTION
This allows callers to distinguish between tile sources w/o available TileJSON endpoints (e.g. `http://tileserver/{z}/{x}/{y}.png`, using [`tilelive-http`](https://github.com/mojodna/tilelive-http)) and HTTP-accessible TileJSON (e.g. `tilejson+http://tileserver/index.json`, using `tilejson`).
