### PR TITLE
Fall back to the upstream Content-Type

### DIFF
--- a/lib/tilejson.js
+++ b/lib/tilejson.js
@@ -144,7 +144,7 @@ TileJSON.prototype.getTile = function(z, x, y, callback) {
 
         var modified = headers['last-modified'] ? new Date(headers['last-modified']) : new Date;
         var responseHeaders = {
-            'Content-Type': getMimeType(data),
+            'Content-Type': getMimeType(data) || headers['content-type'],
             'Last-Modified': modified,
             'ETag': headers['etag'] || (headers['content-length'] + '-' + +modified)
         };


### PR DESCRIPTION
When loading PBFs via `tilejson`, `Content-Type` is coming back `undefined` (because `getMimeType()` doesn't know what to make of them).  This falls back to using the upstream-provided `Content-Type`.

Is there a reason that the upstream isn't inherently trusted to know what it's serving?
