### PR TITLE
Delete lock before callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
         "retry": "0.6.0"
     },
     "devDependencies": {
-        "mocha": "*",
-        "step": "0.0.5"
+        "mocha": "*"
     },
     "scripts": {
         "test": "mocha -R spec"


### PR DESCRIPTION
Closes #13

Resolves a condition where a callback triggers a new lock request for the same file, which hits a previous lock that should not exist at that point. Added tests for this condition as well.

/cc @yhahn
