### PR TITLE
Include error causes in messaging

### DIFF
--- a/lib/tilejson.js
+++ b/lib/tilejson.js
@@ -61,7 +61,7 @@ function TileJSON(uri, callback) {
             uri.protocol = uri.protocol.replace(/.*(https?:)/, '$1');
             tilejson.get(url.format(uri), function(err, buffer) {
                 if (err && (err.status == 403 || err.status == 404))
-                    return callback(new Error('Tileset does not exist'));
+                    return callback(new Error('Tileset does not exist: ' + url.format(uri)));
                 if (err)
                     return callback(err);
                 var data;

--- a/test/tilejson.test.js
+++ b/test/tilejson.test.js
@@ -109,8 +109,9 @@ describe('load http', function() {
     });
 
     it('errors on 404', function(done) {
-        new TileJSON('http://a.tiles.mapbox.com/v3/mapbox.doesnotexist.json', function(err, source) {
-            assert.equal('Tileset does not exist', err.message);
+        var uri = 'http://a.tiles.mapbox.com/v3/mapbox.doesnotexist.json';
+        new TileJSON(uri, function(err, source) {
+            assert.equal('Tileset does not exist: ' + uri, err.message);
             done();
         });
     });


### PR DESCRIPTION
Because it's convenient to know *which* tileset doesn't exist.