### PR TITLE
Support ?scale if autoscale=true

### DIFF
--- a/lib/tilejson.js
+++ b/lib/tilejson.js
@@ -41,6 +41,7 @@ function TileJSON(uri, callback) {
         this.data = uri.data;
     }
     uri.query = uri.query || {};
+    this.scale = uri.query.scale || 1;
 
     var tilejson = this;
     var key = uri.data ? JSON.stringify(uri.data) : url.format(uri);
@@ -153,11 +154,18 @@ TileJSON.prototype.getTile = function(z, x, y, callback) {
 };
 
 TileJSON.prototype._prepareURL = function(url, z, x, y) {
-    return (url
+    var tileUrl = (url
         .replace(/\{prefix\}/g, (x%16).toString(16) + (y%16).toString(16))
         .replace(/\{z\}/g, z)
         .replace(/\{x\}/g, x)
         .replace(/\{y\}/g, (this.data.scheme === 'tms') ? (1 << z) - 1 - y : y));
+
+    if (this.scale > 1 && this.data.autoscale) {
+        // replace the last "." with "@<scale>x."
+        tileUrl = tileUrl.replace(/\.(?!.*\.)/, "@" + this.scale + "x.")
+    }
+
+    return tileUrl;
 };
 
 // z, x, y are XYZ coordinates.


### PR DESCRIPTION
If `TileJSON` has been loaded with a scale factor > 1 and the source TileJSON reports `autoscale: true`, fetch tiles matching the requested scale (typically 2) in `getTile`.
