### PR TITLE
Evil version of deflate/gzip decoding of mapnik vector tiles

### DIFF
--- a/lib/tilejson.js
+++ b/lib/tilejson.js
@@ -143,20 +143,22 @@ TileJSON.prototype.getTile = function(z, x, y, callback) {
         if (err) return callback(err);
 
         var modified = headers['last-modified'] ? new Date(headers['last-modified']) : new Date();
-        var responseHeaders = {};
-        responseHeaders['Content-Type'] = headers['content-type'] || tiletype.contentType(data);
+        var datatype = tiletype.type(data);
+        var responseHeaders = tiletype.headers(datatype);
         responseHeaders['Last-Modified'] = modified;
         responseHeaders.ETag = headers.etag || (headers['content-length'] + '-' + (+modified));
         if (headers['cache-control']) {
             responseHeaders['Cache-Control'] = headers['cache-control'];
         }
 
-        if (headers['content-encoding'] === 'deflate') {
+        if (datatype === 'deflate') {
             zlib.inflate(data, function (err, data) {
+                delete responseHeaders['Content-Encoding'];
                 callback(err, data, responseHeaders);
             });
-        } else if (headers['content-encoding'] === 'gzip') {
+        } else if (datatype === 'gzip') {
             zlib.gunzip(data, function (err, data) {
+                delete responseHeaders['Content-Encoding'];
                 callback(err, data, responseHeaders);
             });
         } else {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "get": "1.3.x",
     "agentkeepalive": "0.1.x",
-    "tiletype": "git+https://github.com/mapbox/tiletype.git#content-encoding"
+    "tiletype": "git+https://github.com/mapbox/tiletype.git#content-encoding-evil"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
Removes trust of content-encoding header from https://github.com/mapbox/node-tilejson/pull/27.
