### PR TITLE
fix qs is not defined

### DIFF
--- a/lib/tilejson.js
+++ b/lib/tilejson.js
@@ -2,6 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var url = require('url');
 var get = require('get');
+var qs = require('querystring');
 var tiletype = require('tiletype');
 var EventEmitter = require('events').EventEmitter;
 var Agent = require('agentkeepalive');


### PR DESCRIPTION
test case
```
    tape('loads a tilejson file with tilejson+http: and access_token', function(assert) {
		var url_with_access_token = 'tilejson+http://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v5.json?access_token=pk.eyJ1IjoiaGFuY2hhbyIsImEiOiI1RTIwNkkwIn0.ht9ldcZjv7VtmF41F7DhRg';
		url_with_access_token = url.parse(url_with_access_token);
        new TileJSON(url_with_access_token, function(err, source) {
            assert.ifError(err);
            assert.ok(source.data);
			assert.end();
        });
    });
```