### PR TITLE
Enable 3rd party vector tile sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+_site
+.settings
+*.7z
+node_modules
+node.exe

--- a/lib/tilejson.js
+++ b/lib/tilejson.js
@@ -217,7 +217,7 @@ TileJSON.prototype.get = function(url, callback) {
         //expect gzipped buffers.
         //let requestjs unzip all other requests, as gzipped responses
         //break stuff further down the line.
-        gzip: !(-1 < url.indexOf('.pbf') || -1 < url.indexOf('.mvt')),
+        gzip: !(url.indexOf('.pbf') > -1 || url.indexOf('.mvt') > -1),
         timeout: tilejson.timeout,
         headers: {
             Connection: 'Keep-Alive',

--- a/lib/tilejson.js
+++ b/lib/tilejson.js
@@ -211,8 +211,21 @@ TileJSON.prototype.get = function(url, callback) {
     var opts = {
         url: url,
         encoding: null,
+        //TODO: find a clean solution
+        //tell requestjs to *not* unzip, on the fly when fetching
+        //vetor tiles (*.pbf *.mvt), because all tile* modules
+        //expect gzipped buffers.
+        //let requestjs unzip all other requests, as gzipped responses
+        //break stuff further down the line.
+        gzip: !(-1 < url.indexOf('.pbf') || -1 < url.indexOf('.mvt')),
         timeout: tilejson.timeout,
-        headers: {Connection: 'Keep-Alive'},
+        headers: {
+            Connection: 'Keep-Alive',
+            //always send gzip header, to enable 3rd party vector tile
+            //sources that gzip their response according to this header
+            //being present
+            'Accept-Encoding': 'gzip;q=1, identity;q=0'
+        },
         agent: url.indexOf('https:') === 0 ? httpsagent : agent
     };
 


### PR DESCRIPTION
@yhahn do you have time to review/test/merge, or tell me, whom else I should ask?
@springmeyer FYI

**It's a _hack_, any suggestions for a clean solution are welcome**
#### Current State
- about to release next Mapbox Studio version
- with the adoption of vector tiles 3rd party vector tile services will be more common and the need to style them with MBS, too.
- MBS does not sent `Accept-Encoding:gzip`, because mapbox servers always send gzipped vector tiles
- `tile* modules` expect gzipped vector tiles
- 3rd party servers compress their response, depending on the presence of `Accept-Encoding`
  - e.g.: wikimedia: https://github.com/mapbox/mapbox-studio/issues/1268#issuecomment-134004721
- as MBS sends requests without `Accept-Encoding:gzip`, servers respond with uncompressed content
- this uncompressed response breaks `tile*` modules
- just adding `Accept-Encoding:gzip` to requestjs header options, makes the 3rd party vector tiles work, but breaks other stuff, as uncompressed content is expected.
- adding `gzip:true` to requestjs options makes the other stuff work, because requestjs decompresses on the fly, but breaks the 3rd party vector tiles as they are also decompressed before being passed to the tile\* modules.
#### Obvious problem

If 3rd party tile services use a different extension than `.pbf` or `.mvt`
#### Hacky Solution
- always send `Accept-Encoding:gzip` header to get gzipped responses
- let requestjs decompress (or not) on a pre request basis (`gzip:[true|false]`).  currently I'm checking, if 
  - there is `.pbf` or `.mvt` in the url => do nothing: `gzip:false`
  - if not => uncompress: `gzip:true`
#### Manual tests

I tried
- Mapbox Styles: streets, satellite, comic, ...
- custom styles with custom source hosted by Mapbox
- custom styles with 3rd party tile services: Mapzen and Wikimedia

Didn't ru into any problems
