### PR TITLE
Always report the scheme as XYZ

### DIFF
--- a/lib/tilejson.js
+++ b/lib/tilejson.js
@@ -136,7 +136,11 @@ TileJSON.findID = function(filepath, id, callback) {
 
 TileJSON.prototype.getInfo = function(callback) {
     if (!this.data) callback(new Error('Tilesource not loaded'));
-    else callback(null, this.data);
+    else {
+        // prepareURL transforms so that coordinates are always output as XYZ
+        this.data.scheme = 'xyz';
+        callback(null, this.data);
+    }
 };
 
 // z, x, y are XYZ coordinates.

--- a/test/tilejson.test.js
+++ b/test/tilejson.test.js
@@ -337,6 +337,14 @@ tape('findID', function(assert) {
             assert.end();
         });
     });
+
+    tape('should set scheme as xyz', function(assert) {
+        grid_source.getInfo(function(err, info) {
+            if (err) throw err;
+            assert.equal('xyz', info.scheme);
+            assert.end();
+        });
+    });
 })();
 
 (function() {


### PR DESCRIPTION
Sources with TMS schemes are transparently transformed into XYZ coordinates. Prior to this, TMS sources would have their schemes forwarded as `tms` even though the effective coordinates are `xyz`.