### PR TITLE
Updated to be under mapbox namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A javascript implementation of https://github.com/mapbox/tilejson-spec
 ## install
 
 ```
-npm install --save tilejson
+npm install --save @mapbox/tilejson
 ```
 
 ## API

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tilejson",
+  "name": "@mapbox/tilejson",
   "description": "Tile source backend for online tile sources",
   "version": "1.0.3",
   "author": "Mapbox (https://www.mapbox.com)",


### PR DESCRIPTION
/cc @mapsam
- [ ] Run `npm publish --access=public` to publish the first namespaced version
- [ ] Run `npm deprecate tilejson "This module has moved: please install @mapbox/tilejson instead"`